### PR TITLE
Add manual build workflow

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -1,0 +1,27 @@
+name: Manual Build
+
+on:
+  workflow_dispatch:
+
+env:
+  DOTNET_VERSION: '9.0.x'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+      - name: Restore dependencies
+        run: dotnet restore Jellyfin.sln
+      - name: Build solution
+        run: dotnet build Jellyfin.sln --configuration Release --no-restore
+      - name: Publish server
+        run: dotnet publish Jellyfin.Server --configuration Release --no-restore --output build_output
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: jellyfin-server
+          path: build_output/


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow for manually compiling Jellyfin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f63c2d3bc8326a7e2d7542cdc45d3