### PR TITLE
Add library display mode preference

### DIFF
--- a/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
+++ b/Jellyfin.Api/Controllers/DisplayPreferencesController.cs
@@ -91,6 +91,14 @@ public class DisplayPreferencesController : BaseJellyfinApiController
 
         // Load all custom display preferences
         var customDisplayPreferences = _displayPreferencesManager.ListCustomItemDisplayPreferences(displayPreferences.UserId, itemId, displayPreferences.Client);
+
+        // Ensure a default value for the library home display mode
+        if (!customDisplayPreferences.TryGetValue("libraryHomeDisplayMode", out var mode)
+            || !Enum.TryParse<LibraryHomeDisplayMode>(mode, true, out _))
+        {
+            customDisplayPreferences["libraryHomeDisplayMode"] = LibraryHomeDisplayMode.DateAdded.ToString().ToLowerInvariant();
+        }
+
         foreach (var (key, value) in customDisplayPreferences)
         {
             dto.CustomPrefs.TryAdd(key, value);
@@ -199,6 +207,12 @@ public class DisplayPreferencesController : BaseJellyfinApiController
                 _logger.LogError("Invalid ViewType: {LandingScreenOption}", displayPreferences.CustomPrefs[key]);
                 displayPreferences.CustomPrefs.Remove(key);
             }
+        }
+
+        if (displayPreferences.CustomPrefs.TryGetValue("libraryHomeDisplayMode", out var newMode)
+            && !Enum.TryParse<LibraryHomeDisplayMode>(newMode, true, out _))
+        {
+            displayPreferences.CustomPrefs.Remove("libraryHomeDisplayMode");
         }
 
         var itemPrefs = _displayPreferencesManager.GetItemDisplayPreferences(existingDisplayPreferences.UserId, itemId, existingDisplayPreferences.Client);

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Enums/LibraryHomeDisplayMode.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Enums/LibraryHomeDisplayMode.cs
@@ -1,0 +1,22 @@
+namespace Jellyfin.Database.Implementations.Enums;
+
+/// <summary>
+/// An enum representing how library media should be displayed on the home screen.
+/// </summary>
+public enum LibraryHomeDisplayMode
+{
+    /// <summary>
+    /// Display items ordered by the date they were added.
+    /// </summary>
+    DateAdded = 0,
+
+    /// <summary>
+    /// Display items ordered by their release date.
+    /// </summary>
+    ReleaseDate = 1,
+
+    /// <summary>
+    /// Display two rows, one by date added and one by release date.
+    /// </summary>
+    Both = 2
+}


### PR DESCRIPTION
## Summary
- introduce `LibraryHomeDisplayMode` enum
- default library home display mode to `DateAdded`
- validate `libraryHomeDisplayMode` when saving display preferences

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f62ed7fa483268bbf75aa56953f80