### PR TITLE
Add release date sorting option for latest media

### DIFF
--- a/Emby.Server.Implementations/Library/UserViewManager.cs
+++ b/Emby.Server.Implementations/Library/UserViewManager.cs
@@ -359,7 +359,7 @@ namespace Emby.Server.Implementations.Library
                 IncludeItemTypes = includeItemTypes,
                 OrderBy = new[]
                 {
-                    (ItemSortBy.DateCreated, SortOrder.Descending),
+                    (request.SortBy, SortOrder.Descending),
                     (ItemSortBy.SortName, SortOrder.Descending),
                     (ItemSortBy.ProductionYear, SortOrder.Descending)
                 },

--- a/Jellyfin.Api/Controllers/UserLibraryController.cs
+++ b/Jellyfin.Api/Controllers/UserLibraryController.cs
@@ -516,6 +516,7 @@ public class UserLibraryController : BaseJellyfinApiController
     /// <param name="enableUserData">Optional. include user data.</param>
     /// <param name="limit">Return item limit.</param>
     /// <param name="groupItems">Whether or not to group items into a parent container.</param>
+    /// <param name="sortBy">Field used to sort items. Defaults to date added.</param>
     /// <response code="200">Latest media returned.</response>
     /// <returns>An <see cref="OkResult"/> containing the latest media.</returns>
     [HttpGet("Items/Latest")]
@@ -531,7 +532,8 @@ public class UserLibraryController : BaseJellyfinApiController
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ImageType[] enableImageTypes,
         [FromQuery] bool? enableUserData,
         [FromQuery] int limit = 20,
-        [FromQuery] bool groupItems = true)
+        [FromQuery] bool groupItems = true,
+        [FromQuery] ItemSortBy? sortBy = null)
     {
         var requestUserId = RequestHelpers.GetUserId(User, userId);
         var user = _userManager.GetUserById(requestUserId);
@@ -561,6 +563,7 @@ public class UserLibraryController : BaseJellyfinApiController
                 Limit = limit,
                 ParentId = parentId ?? Guid.Empty,
                 User = user,
+                SortBy = sortBy ?? ItemSortBy.DateCreated,
             },
             dtoOptions);
 
@@ -599,6 +602,7 @@ public class UserLibraryController : BaseJellyfinApiController
     /// <param name="enableUserData">Optional. include user data.</param>
     /// <param name="limit">Return item limit.</param>
     /// <param name="groupItems">Whether or not to group items into a parent container.</param>
+    /// <param name="sortBy">Field used to sort items. Defaults to date added.</param>
     /// <response code="200">Latest media returned.</response>
     /// <returns>An <see cref="OkResult"/> containing the latest media.</returns>
     [HttpGet("Users/{userId}/Items/Latest")]
@@ -616,7 +620,8 @@ public class UserLibraryController : BaseJellyfinApiController
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ImageType[] enableImageTypes,
         [FromQuery] bool? enableUserData,
         [FromQuery] int limit = 20,
-        [FromQuery] bool groupItems = true)
+        [FromQuery] bool groupItems = true,
+        [FromQuery] ItemSortBy? sortBy = null)
         => GetLatestMedia(
             userId,
             parentId,
@@ -628,7 +633,8 @@ public class UserLibraryController : BaseJellyfinApiController
             enableImageTypes,
             enableUserData,
             limit,
-            groupItems);
+            groupItems,
+            sortBy);
 
     private async Task RefreshItemOnDemandIfNeeded(BaseItem item)
     {

--- a/MediaBrowser.Model/Querying/LatestItemsQuery.cs
+++ b/MediaBrowser.Model/Querying/LatestItemsQuery.cs
@@ -13,6 +13,7 @@ namespace MediaBrowser.Model.Querying
         public LatestItemsQuery()
         {
             EnableImageTypes = Array.Empty<ImageType>();
+            SortBy = ItemSortBy.DateCreated;
         }
 
         /// <summary>
@@ -81,5 +82,11 @@ namespace MediaBrowser.Model.Querying
         /// </summary>
         /// <value>The enable image types.</value>
         public ImageType[] EnableImageTypes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the field used to sort the latest items.
+        /// Defaults to <see cref="ItemSortBy.DateCreated"/>.
+        /// </summary>
+        public ItemSortBy SortBy { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- add `SortBy` field to `LatestItemsQuery`
- allow latest media endpoints to accept an optional `sortBy` query
- use given sort order in user view manager

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f58b6b1388326ab4d09f586e8606b