### PR TITLE
Add Portainer docker compose

### DIFF
--- a/deployment/portainer/README.md
+++ b/deployment/portainer/README.md
@@ -1,0 +1,12 @@
+# Portainer Stack
+
+This directory contains a simple Docker Compose file that can be used to deploy Jellyfin through Portainer.
+
+## Usage
+
+1. In Portainer, navigate to **Stacks** and select **Add stack**.
+2. Copy the contents of `docker-compose.yml` into the web editor or upload the file.
+3. Adjust the volume paths if needed to point to your media and configuration directories.
+4. Deploy the stack.
+
+The container runs in host network mode and maps `./config`, `./cache` and `./media` directories on the host for persistent storage. Adjust the directories to suit your environment.

--- a/deployment/portainer/docker-compose.yml
+++ b/deployment/portainer/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.8"
+services:
+  jellyfin:
+    image: jellyfin/jellyfin:latest
+    container_name: jellyfin
+    user: 1000:1000
+    network_mode: host
+    volumes:
+      - ./config:/config
+      - ./cache:/cache
+      - ./media:/media
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add a docker-compose file for Portainer users
- document usage instructions

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f6a046050832686d4d3b100516c11