### PR TITLE
Add Windows build workflow

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,33 @@
+name: Windows Build
+
+on:
+  workflow_dispatch:
+
+env:
+  DOTNET_VERSION: '9.0.x'
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+      - name: Restore dependencies
+        run: dotnet restore Jellyfin.sln
+      - name: Build solution
+        run: dotnet build Jellyfin.sln --configuration Release --no-restore
+      - name: Publish Windows x64
+        run: |
+          dotnet publish Jellyfin.Server \
+            --configuration Release \
+            --no-restore \
+            --runtime win-x64 \
+            --self-contained true \
+            --output build_output
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: jellyfin-windows
+          path: build_output/


### PR DESCRIPTION
## Summary
- add `windows-build.yml` to publish a self-contained Windows x64 executable

## Testing
- `dotnet test Jellyfin.sln --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f7a7f1fe8832697031b2a5e3a478b